### PR TITLE
Enable TLS on the status_listen port

### DIFF
--- a/kong.conf
+++ b/kong.conf
@@ -4,7 +4,7 @@ database = off
 declarative_config = /home/vcap/app/kong.yaml
 proxy_listen = 0.0.0.0:8080
 admin_listen = 127.0.0.1:8081 http2 ssl reuseport backlog=16384
-status_listen = 0.0.0.0:8100
+status_listen = 0.0.0.0:8100 ssl
 log_level = notice
 proxy_access_log = /dev/stdout
 proxy_error_log = /dev/stderr


### PR DESCRIPTION
In order to move towards an encryption-everywhere environment, its
necessary to enable TLS by default on all ports that Kong listens on.
