### PR TITLE
remove staticfile services

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,5 +64,3 @@ jobs:
       - name: Apply CF Network Policies
         run: |
           cf add-network-policy api-gateway sk-api
-          cf add-network-policy api-gateway sk-portal
-          cf add-network-policy api-gateway sk-sdk

--- a/kong-config.yaml
+++ b/kong-config.yaml
@@ -1,26 +1,6 @@
 ---
 _format_version: "1.1"
 services:
-  - name: sk-portal
-    url: http://identity-idva-sk-portal-${ENVIRONMENT_NAME}.apps.internal:8080
-    routes:
-      - name: sk-portal-route
-        methods:
-          - GET
-        hosts:
-          - idva-portal-${ENVIRONMENT_NAME}.app.cloud.gov
-        protocols:
-          - http
-  - name: sk-sdk
-    url: http://identity-idva-sk-sdk-${ENVIRONMENT_NAME}.apps.internal:8080
-    routes:
-      - name: sk-sdk-route
-        methods:
-          - GET
-        hosts:
-          - idva-sdk-${ENVIRONMENT_NAME}.app.cloud.gov
-        protocols:
-          - http
   - name: sk-api
     url: http://identity-idva-sk-api-${ENVIRONMENT_NAME}.apps.internal:8080
     routes:

--- a/manifest.yml
+++ b/manifest.yml
@@ -12,8 +12,6 @@ applications:
     command: ./run.sh
     routes:
       - route: idva-api-((ENVIRONMENT_NAME)).app.cloud.gov
-      - route: idva-portal-((ENVIRONMENT_NAME)).app.cloud.gov
-      - route: idva-sdk-((ENVIRONMENT_NAME)).app.cloud.gov
       - route: idva-((ENVIRONMENT_NAME)).apps.internal
     env:
       ENVIRONMENT_NAME: ((ENVIRONMENT_NAME))


### PR DESCRIPTION
- Remove service setup for staticfile assets
- Remove route setup for staticfile assets

Moving the two staticfile apps to have public urls. There is no longer a need to route
this traffic through Kong and use internal services.