### PR TITLE
Bump Kong from v2.5.1 to v2.6.0

### DIFF
--- a/apt.yml
+++ b/apt.yml
@@ -2,5 +2,5 @@
 repos:
   - deb [trusted=yes] https://download.konghq.com/gateway-2.x-ubuntu-bionic/ default all
 packages:
-  - kong=2.5.1
+  - kong=2.6.0
   - gettext-base


### PR DESCRIPTION
Version 2.6 includes many internal dependency updates for Kong as well
as minor changes to the plugin system. See the full changelog here:
https://github.com/Kong/kong/blob/2.6.0/CHANGELOG.md#260
