### PR TITLE
Update Kong to 2.7

### DIFF
--- a/apt.yml
+++ b/apt.yml
@@ -2,5 +2,5 @@
 repos:
   - deb [trusted=yes] https://download.konghq.com/gateway-2.x-ubuntu-bionic/ default all
 packages:
-  - kong=2.6.0
+  - kong=2.7.0
   - gettext-base


### PR DESCRIPTION
Version 2.7 currently deployed to `dev` successfully.