### PR TITLE
Move Kong to a closed-egress space

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,6 +32,7 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
+          space-suffix: "-closed"
 
       - name: Deploy application
         run: cf push
@@ -41,5 +42,5 @@ jobs:
 
       - name: Apply CF Network Policies
         run: |
-          cf add-network-policy kong sk-api --protocol tcp --port 61443
-          cf add-network-policy kong keycloak --protocol tcp --port 61443
+          cf add-network-policy kong sk-api --protocol tcp --port 61443 -s ${{ steps.cf-setup.outputs.target-environment }}
+          cf add-network-policy kong keycloak --protocol tcp --port 61443 -s ${{ steps.cf-setup.outputs.target-environment }}


### PR DESCRIPTION
Kong will have a public route attached to it. It will be able to respond
to incoming traffic, but does not need to initiate any connections to
the public internet or internal brokered services.

The route from Kong to sk-api now must specify the space that the sk-api
will be in, which should be the default environment space (dev, test,
prod).
