### PR TITLE
Fix path of dependancies for kong

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ LOCAL='/home/vcap/deps/0/apt/usr/local'
 
 export LD_LIBRARY_PATH=$LOCAL/lib:$LOCAL/lib/lua/5.1/:$LOCAL/openresty/luajit/lib:$LOCAL/openresty/pcre/lib:$LOCAL/openresty/openssl111/lib:$LD_LIBRARY_PATH
 export LUA_PATH="$LOCAL/share/lua/5.1/?.lua;$LOCAL/share/lua/5.1/?/init.lua;$LOCAL/openresty/lualib/?.lua"
-export LUA_CPATH="$LOCAL/lib/lua/5.1/?.so"
+export LUA_CPATH="$LOCAL/lib/lua/5.1/?.so;$LOCAL/openresty/lualib/?.so"
 export PATH=$LOCAL/bin/:$LOCAL/openresty/nginx/sbin:$LOCAL/openresty/bin:$PATH
 
 # Ensure references to /usr/local resolve correctly


### PR DESCRIPTION
The path of the cjson library changed in a recent kong version.