### PR TITLE
Rewrite kong.conf

### DIFF
--- a/kong.conf
+++ b/kong.conf
@@ -1,13 +1,37 @@
-# disable fingerprinted headers on all http responses
-headers = off
-database = off
-declarative_config = /home/vcap/app/kong.yaml
-proxy_listen = 0.0.0.0:8080
-admin_listen = 127.0.0.1:8081 http2 ssl reuseport backlog=16384
-status_listen = 0.0.0.0:8100 ssl
-log_level = notice
-proxy_access_log = /dev/stdout
-proxy_error_log = /dev/stderr
-admin_access_log = /dev/stdout
-admin_error_log = /dev/stderr
+# Disable Nginx Daemon so that Kong runs as a foreground process
 nginx_daemon = off
+
+# Set spawned worker processes to 1 to keep memory usage at a reasonable level and promote
+# horizontal scaling on CloudFoundry
+nginx_worker_processes = 1
+
+# Comma-separated list of headers Kong should inject in client responses. 
+# 'off' prevents Kong from injecting any headers by default. Does not prevent plugins from injecting headers of their own.
+headers = off
+
+# Turn database off in dbless mode
+database = off
+
+# The path to the declarative configuration file which holds the specification of all
+# entities (Routes, Services, Consumers, etc.) to be used when the database is set to "off".
+declarative_config = /home/vcap/app/kong.yaml
+
+# Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic.
+#proxy_listen = off # 0.0.0.0:8080
+proxy_listen = 0.0.0.0:8080
+
+# Comma-separated list of addresses and ports on which the Admin interface should listen.
+admin_listen = 127.0.0.1:8081 http2 ssl reuseport backlog=16384
+
+# Comma-separated list of addresses and ports on which the Status API should listen.
+status_listen = 0.0.0.0:8100 ssl
+
+# Set access log locations -> stdout
+proxy_access_log = /dev/stdout
+admin_access_log = /dev/stdout
+status_access_log = /dev/stdout
+
+# Set error log locations -> stderr
+proxy_error_log = /dev/stderr
+admin_error_log = /dev/stderr
+status_error_log = /dev/stderr


### PR DESCRIPTION
Notable changes include setting nginx_worker_processes=1, setting status
access and error log locations to stdout, and adding much more
descriptive comments for each of our configured customizations.
