### PR TITLE
Use CF Instance Identity Certs for status API

### DIFF
--- a/kong.conf.template
+++ b/kong.conf.template
@@ -26,6 +26,9 @@ admin_listen = 127.0.0.1:8081 http2 ssl reuseport backlog=16384
 # Comma-separated list of addresses and ports on which the Status API should listen.
 status_listen = 0.0.0.0:8100 ssl
 
+status_ssl_cert = $CF_INSTANCE_CERT
+status_ssl_cert_key = $CF_INSTANCE_KEY
+
 # Set access log locations -> stdout
 proxy_access_log = /dev/stdout
 admin_access_log = /dev/stdout

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,7 @@ export KONG_LUA_PACKAGE_CPATH=$LUA_CPATH
 
 # Generate the kong.yaml state file
 /home/vcap/deps/0/apt/usr/bin/envsubst < kong-config.yaml > /home/vcap/app/kong.yaml
+/home/vcap/deps/0/apt/usr/bin/envsubst < kong.conf.template > /home/vcap/app/kong.conf
 
 # Start the main Kong application.
 kong start -c ./kong.conf --v


### PR DESCRIPTION
In order to use fully-validated TLS connections to the Kong status API,
we can configure the status API to utilize the CF Instance Identity
certificates, which contain the IP SAN for the application. This allows
Prometheus to connect to Kong and validate the certificate as normal,
since Prometheus is using the IP address, rather than the route, to
connect to Kong for metric info.
