### PR TITLE
move flow client route to kong ingress

### DIFF
--- a/ingress/kong-config.yaml
+++ b/ingress/kong-config.yaml
@@ -25,6 +25,21 @@ services:
           - idva-sdk-${ENVIRONMENT_NAME}.app.cloud.gov
         protocols:
           - http
+  - name: flow-client
+    url: https://idva-flow-client-${ENVIRONMENT_NAME}.apps.internal:61443
+    routes:
+      - name: flow-client-host-route
+        hosts:
+          - idva-client-${ENVIRONMENT_NAME}.app.cloud.gov
+        protocols:
+          - http
+      - name: flow-client-path-route
+        paths:
+          - /client
+        hosts:
+          - idva-${ENVIRONMENT_NAME}.app.cloud.gov
+        protocols:
+          - http
   - name: keycloak
     url: https://identity-idva-keycloak-${ENVIRONMENT_NAME}.apps.internal:61443
     routes:

--- a/ingress/manifest.yml
+++ b/ingress/manifest.yml
@@ -16,6 +16,7 @@ applications:
       - route: idva-api-((ENVIRONMENT_NAME)).app.cloud.gov
       - route: idva-sdk-((ENVIRONMENT_NAME)).app.cloud.gov
       - route: idva-portal-((ENVIRONMENT_NAME)).app.cloud.gov
+      - route: idva-client-((ENVIRONMENT)).app.cloud.gov
       - route: identity-idva-kong-((ENVIRONMENT_NAME)).apps.internal
     env:
       ENVIRONMENT_NAME: ((ENVIRONMENT_NAME))


### PR DESCRIPTION
This change centralizes the public routes under kong ingress to allow better control over them. Additionally the path route will facilitate a transition to using paths under a single public hostname