### PR TITLE
Add /kibana path to upstream service

### DIFF
--- a/internal/kong-config.yaml
+++ b/internal/kong-config.yaml
@@ -2,7 +2,7 @@
 _format_version: "1.1"
 services:
   - name: kibana
-    url: https://identity-idva-monitoring-kibana-${ENVIRONMENT_NAME}.apps.internal:61443/
+    url: https://identity-idva-monitoring-kibana-${ENVIRONMENT_NAME}.apps.internal:61443/kibana/
     routes:
       - name: kibana-host-route
         hosts:


### PR DESCRIPTION
Allows IDVA developers to visit the kibana dashboard using the internal kong gateway.

LIMITATION: Currently using the path-based route matching is required (i.e. `localhost:8080/kibana` to get to the dashboard). Using the host-based route matching results in Kibana responding with a JSON-encoded 404 error that I believe is related to this outstanding Kibana issue https://github.com/elastic/kibana/issues/62144